### PR TITLE
include correct contract addr in ReferralsClient

### DIFF
--- a/internal/services/referrals.go
+++ b/internal/services/referrals.go
@@ -43,7 +43,7 @@ func NewReferralBonusService(
 
 	return &ReferralsClient{
 		TransferService: transferService,
-		ContractAddress: common.HexToAddress(settings.IssuanceContractAddress),
+		ContractAddress: common.HexToAddress(settings.ReferralContractAddress),
 		Week:            week,
 		Logger:          logger,
 		UsersClient:     userClient,


### PR DESCRIPTION
client was being initialized with the wrong address