### PR TITLE
SI-2390-create-mtree-log-root

### DIFF
--- a/cmd/rewards-api/main.go
+++ b/cmd/rewards-api/main.go
@@ -288,6 +288,8 @@ func main() {
 			logger.Fatal().Err(err).Msg("Failed to create Kafka producer.")
 		}
 
+		attestationService := services.NewAttestor(&logger)
+
 		transferService := services.NewTokenTransferService(&settings, producer, pdb)
 
 		devicesConn, err := grpc.Dial(settings.DevicesAPIGRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -306,7 +308,7 @@ func main() {
 
 		definitionsClient := pb_defs.NewDeviceDefinitionServiceClient(definitionsConn)
 
-		baselineRewardClient := services.NewBaselineRewardService(&settings, transferService, services.NewDeviceDataClient(&settings), deviceClient, definitionsClient, week, &logger)
+		baselineRewardClient := services.NewBaselineRewardService(&settings, transferService, services.NewDeviceDataClient(&settings), deviceClient, definitionsClient, attestationService, week, &logger)
 
 		if err := baselineRewardClient.BaselineIssuance(); err != nil {
 			logger.Fatal().Err(err).Int("issuanceWeek", week).Msg("Failed to calculate and/or transfer rewards.")

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/swaggo/swag v1.16.2
 	github.com/testcontainers/testcontainers-go v0.26.0
+	github.com/txaty/go-merkletree v0.2.2
 	github.com/volatiletech/null/v8 v8.1.2
 	github.com/volatiletech/sqlboiler/v4 v4.15.0
 	github.com/volatiletech/strmangle v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT
 github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
+github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
+github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -839,6 +841,8 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/txaty/go-merkletree v0.2.2 h1:K5bHDFK+Q3KK+gEJeyTOECKuIwl/LVo4CI+cm0/p34g=
+github.com/txaty/go-merkletree v0.2.2/go.mod h1:w5HPEu7ubNw5LzS+91m+1/GtuZcWHKiPU3vEGi+ThJM=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/urfave/cli v1.22.12 h1:igJgVw1JdKH+trcLWLeLwZjU9fEfPesQ+9/e4MQ44S8=

--- a/internal/services/attestor.go
+++ b/internal/services/attestor.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/rs/zerolog"
+	mt "github.com/txaty/go-merkletree"
+)
+
+const validCredentialRange = time.Hour * 24 * 7
+
+type leaf struct {
+	data []byte
+}
+
+func (l *leaf) Serialize() ([]byte, error) {
+	// since OpenZep will sort bytes before hashing
+	// abi encoding and serialization is performed before
+	// we pass any data to the merkle tree func
+	// thus, we can just return the bytes directly here
+	return l.data, nil
+}
+
+func abiEncode(types []string, values []interface{}) ([]byte, error) {
+	if len(types) != len(values) {
+		return nil, fmt.Errorf("type array  and value array must be same length")
+	}
+
+	args := abi.Arguments{}
+	for _, argType := range types {
+		abiType, err := abi.NewType(argType, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, abi.Argument{Type: abiType})
+	}
+
+	return args.Pack(values...)
+}
+
+type attestor struct {
+	config mt.Config
+	log    *zerolog.Logger
+}
+
+func NewAttestor(logger *zerolog.Logger) *attestor {
+	return &attestor{
+		config: mt.Config{
+			SortSiblingPairs: true, // parameter for OpenZeppelin compatibility
+			HashFunc: func(data []byte) ([]byte, error) {
+				return crypto.Keccak256(data), nil
+			},
+			Mode:               mt.ModeProofGenAndTreeBuild,
+			DisableLeafHashing: true, // also required for OpenZeppelin compatilibity
+		},
+		log: logger,
+	}
+}
+
+func (w *attestor) GenerateMerkleTree(ctx context.Context, data [][]interface{}, dataTypes []string) (*mt.MerkleTree, error) {
+	fmt.Println("GenerateMerkleTree")
+	encodedLeaves := [][]byte{}
+	for _, d := range data {
+		codeBytes, err := abiEncode(dataTypes, d)
+		if err != nil {
+			w.log.Err(err).Msg("failed to abi encode attestation data")
+		}
+		encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
+	}
+
+	// sort values for OpenZeppelin compatibility
+	sort.Slice(encodedLeaves, func(i, j int) bool {
+		return string(encodedLeaves[i]) < string(encodedLeaves[j])
+	})
+
+	blocks := []mt.DataBlock{}
+	for _, vc := range encodedLeaves {
+		blocks = append(blocks, &leaf{data: vc})
+	}
+
+	return mt.New(&w.config, blocks)
+}
+
+func (w *attestor) VerifyAttestation(root, node []byte, proof [][]byte) (bool, error) {
+	dataBlock := &leaf{data: node}
+	p := mt.Proof{
+		Siblings: proof,
+	}
+	return mt.Verify(dataBlock, &p, root, &w.config)
+
+}

--- a/internal/services/attestor.go
+++ b/internal/services/attestor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -18,14 +19,17 @@ type leaf struct {
 	data []byte
 }
 
+type merkleTreeLeaf struct {
+	VCExpiration time.Time
+	Values       []interface{}
+}
+
 func (l *leaf) Serialize() ([]byte, error) {
-	// since OpenZep will sort bytes before hashing
-	// abi encoding and serialization is performed before
-	// we pass any data to the merkle tree func
-	// thus, we can just return the bytes directly here
 	return l.data, nil
 }
 
+// abiEncode mirrors solidity abi encoding
+// converts data struct into binary format used by openzep merkle tree library
 func abiEncode(types []string, values []interface{}) ([]byte, error) {
 	if len(types) != len(values) {
 		return nil, fmt.Errorf("type array  and value array must be same length")
@@ -48,6 +52,14 @@ type Attestor struct {
 	log    *zerolog.Logger
 }
 
+// NewAttestor creates a new merkle tree attestation service
+// for OpenZep compatilibity:
+// OZ sorts all abi encoded leaves before beginning to build tree
+// as yet, there is no parameter to make this library sort
+// the leaves a priori (sort sibling pairs true refers
+// to sorting hashed sib pairs in later steps)
+// thus, abi encoding and serialization is performed
+// as a first step before we pass any data to the merkle tree func
 func NewAttestor(logger *zerolog.Logger) *Attestor {
 	return &Attestor{
 		config: mt.Config{
@@ -62,19 +74,17 @@ func NewAttestor(logger *zerolog.Logger) *Attestor {
 	}
 }
 
-func (a *Attestor) GenerateMerkleTree(data map[string]map[string]interface{}, dataTypes []string) (*mt.MerkleTree, error) {
+func (a *Attestor) GenerateMerkleTree(data map[string]merkleTreeLeaf, dataTypes []string) (*mt.MerkleTree, error) {
 	encodedLeaves := [][]byte{}
 	for _, device := range data {
-		if _, val := device[Values]; val {
-			codeBytes, err := abiEncode(dataTypes, device[Values].([]interface{}))
-			if err != nil {
-				a.log.Err(err).Msg("failed to abi encode attestation data")
-			}
-			encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
+		codeBytes, err := abiEncode(dataTypes, device.Values)
+		if err != nil {
+			a.log.Err(err).Msg("failed to abi encode attestation data")
 		}
+		encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
 	}
 
-	// sort values for OpenZeppelin compatibility
+	// sort abi encoded values for OpenZeppelin compatibility
 	sort.Slice(encodedLeaves, func(i, j int) bool {
 		return bytes.Compare(encodedLeaves[i], encodedLeaves[j]) < 0
 	})

--- a/internal/services/attestor.go
+++ b/internal/services/attestor.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
@@ -75,7 +76,7 @@ func (a *Attestor) GenerateMerkleTree(data map[string]map[string]interface{}, da
 
 	// sort values for OpenZeppelin compatibility
 	sort.Slice(encodedLeaves, func(i, j int) bool {
-		return string(encodedLeaves[i]) < string(encodedLeaves[j])
+		return bytes.Compare(encodedLeaves[i], encodedLeaves[j]) < 0
 	})
 
 	blocks := []mt.DataBlock{}

--- a/internal/services/attestor.go
+++ b/internal/services/attestor.go
@@ -1,10 +1,8 @@
 package services
 
 import (
-	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -12,7 +10,8 @@ import (
 	mt "github.com/txaty/go-merkletree"
 )
 
-const validCredentialRange = time.Hour * 24 * 7
+var CredentialExpiresAt = "ExprTime"
+var Values = "Values"
 
 type leaf struct {
 	data []byte
@@ -43,13 +42,13 @@ func abiEncode(types []string, values []interface{}) ([]byte, error) {
 	return args.Pack(values...)
 }
 
-type attestor struct {
+type Attestor struct {
 	config mt.Config
 	log    *zerolog.Logger
 }
 
-func NewAttestor(logger *zerolog.Logger) *attestor {
-	return &attestor{
+func NewAttestor(logger *zerolog.Logger) *Attestor {
+	return &Attestor{
 		config: mt.Config{
 			SortSiblingPairs: true, // parameter for OpenZeppelin compatibility
 			HashFunc: func(data []byte) ([]byte, error) {
@@ -62,15 +61,16 @@ func NewAttestor(logger *zerolog.Logger) *attestor {
 	}
 }
 
-func (w *attestor) GenerateMerkleTree(ctx context.Context, data [][]interface{}, dataTypes []string) (*mt.MerkleTree, error) {
-	fmt.Println("GenerateMerkleTree")
+func (a *Attestor) GenerateMerkleTree(data map[string]map[string]interface{}, dataTypes []string) (*mt.MerkleTree, error) {
 	encodedLeaves := [][]byte{}
-	for _, d := range data {
-		codeBytes, err := abiEncode(dataTypes, d)
-		if err != nil {
-			w.log.Err(err).Msg("failed to abi encode attestation data")
+	for _, device := range data {
+		if _, val := device[Values]; val {
+			codeBytes, err := abiEncode(dataTypes, device[Values].([]interface{}))
+			if err != nil {
+				a.log.Err(err).Msg("failed to abi encode attestation data")
+			}
+			encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
 		}
-		encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
 	}
 
 	// sort values for OpenZeppelin compatibility
@@ -83,14 +83,14 @@ func (w *attestor) GenerateMerkleTree(ctx context.Context, data [][]interface{},
 		blocks = append(blocks, &leaf{data: vc})
 	}
 
-	return mt.New(&w.config, blocks)
+	return mt.New(&a.config, blocks)
 }
 
-func (w *attestor) VerifyAttestation(root, node []byte, proof [][]byte) (bool, error) {
+func (a *Attestor) VerifyAttestation(root, node []byte, proof [][]byte) (bool, error) {
 	dataBlock := &leaf{data: node}
 	p := mt.Proof{
 		Siblings: proof,
 	}
-	return mt.Verify(dataBlock, &p, root, &w.config)
+	return mt.Verify(dataBlock, &p, root, &a.config)
 
 }

--- a/internal/services/attestor_test.go
+++ b/internal/services/attestor_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"testing"
@@ -51,7 +52,7 @@ func TestMerkleTreeGeneration(t *testing.T) {
 
 	// sort values for OpenZeppelin compatibility
 	sort.Slice(encodedLeaves, func(i, j int) bool {
-		return string(encodedLeaves[i]) < string(encodedLeaves[j])
+		return bytes.Compare(encodedLeaves[i], encodedLeaves[j]) < 0
 	})
 
 	assert.Equal(len(tree.Proofs), len(encodedLeaves))

--- a/internal/services/attestor_test.go
+++ b/internal/services/attestor_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerkleTreeGeneration(t *testing.T) {
+	ctx := context.Background()
+	assert := assert.New(t)
+	logger := zerolog.Nop()
+	witness := NewAttestor(&logger)
+
+	sampleValues := [][]interface{}{}
+	for i := 1; i < 10; i++ {
+		usr := []interface{}{}
+		usr = append(usr, uint64(i))
+		usr = append(usr, "test")
+		usr = append(usr, "test")
+		usr = append(usr, "test")
+
+		sampleValues = append(sampleValues, usr)
+	}
+
+	sampleTypes := []string{"uint64", "string", "string", "string"}
+	fmt.Println(sampleValues)
+	tree, err := witness.GenerateMerkleTree(ctx, sampleValues, sampleTypes)
+	assert.NoError(err)
+
+	encodedLeaves := [][]byte{}
+	for _, d := range sampleValues {
+		codeBytes, err := abiEncode(sampleTypes, d)
+		assert.NoError(err)
+		encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
+	}
+
+	// sort values for OpenZeppelin compatibility
+	sort.Slice(encodedLeaves, func(i, j int) bool {
+		return string(encodedLeaves[i]) < string(encodedLeaves[j])
+	})
+
+	assert.Equal(len(tree.Proofs), len(encodedLeaves))
+	for i, proof := range tree.Proofs {
+		valid, err := witness.VerifyAttestation(tree.Root, encodedLeaves[i], proof.Siblings)
+		assert.NoError(err)
+		assert.True(valid)
+	}
+}

--- a/internal/services/attestor_test.go
+++ b/internal/services/attestor_test.go
@@ -17,25 +17,23 @@ func TestMerkleTreeGeneration(t *testing.T) {
 	logger := zerolog.Nop()
 	witness := NewAttestor(&logger)
 
-	attestationData := make(map[string]map[string]interface{}, 0)
+	attestationData := map[string]merkleTreeLeaf{}
 	for i := 1; i < 5; i++ {
 		dummyVin := fmt.Sprintf("vin%d", i)
 		currentVCExpiration := time.Now()
-		earningVehicle, ok := attestationData[fmt.Sprintf("vin%d", i)]
+		potentialEarner, ok := attestationData[fmt.Sprintf("vin%d", i)]
 		if ok {
-			credExp, ok := earningVehicle[CredentialExpiresAt]
-			if ok {
-				if credExp.(time.Time).Before(currentVCExpiration) {
-					attestationData[dummyVin] = map[string]interface{}{
-						CredentialExpiresAt: currentVCExpiration,
-						Values:              []interface{}{uint64(i), "deviceDefinitionId", "latestVinCredentialId", "signature"},
-					}
+			if potentialEarner.VCExpiration.Before(currentVCExpiration) {
+				attestationData[dummyVin] = merkleTreeLeaf{
+					VCExpiration: currentVCExpiration,
+					Values:       []interface{}{uint64(i), "deviceDefinitionId", "latestVinCredentialId", "signature"},
 				}
 			}
-		}
-		attestationData[dummyVin] = map[string]interface{}{
-			CredentialExpiresAt: currentVCExpiration,
-			Values:              []interface{}{uint64(i), "deviceDefinitionId", "latestVinCredentialId", "signature"},
+		} else {
+			attestationData[dummyVin] = merkleTreeLeaf{
+				VCExpiration: currentVCExpiration,
+				Values:       []interface{}{uint64(i), "deviceDefinitionId", "latestVinCredentialId", "signature"},
+			}
 		}
 	}
 
@@ -45,7 +43,7 @@ func TestMerkleTreeGeneration(t *testing.T) {
 
 	encodedLeaves := [][]byte{}
 	for _, device := range attestationData {
-		codeBytes, err := abiEncode(sampleTypes, device[Values].([]interface{}))
+		codeBytes, err := abiEncode(sampleTypes, device.Values)
 		assert.NoError(err)
 		encodedLeaves = append(encodedLeaves, crypto.Keccak256(crypto.Keccak256(codeBytes)))
 	}

--- a/internal/services/rewards.go
+++ b/internal/services/rewards.go
@@ -164,7 +164,8 @@ func (t *BaselineClient) assignPoints() error {
 		lastWeekByDevice[reward.UserDeviceID] = reward
 	}
 
-	attestationData := map[string]map[string]interface{}{}
+	attestationData := map[string]merkleTreeLeaf{}
+
 	for _, deviceActivity := range allActiveDeviceRecords {
 		logger := t.Logger.With().Str("userDeviceId", deviceActivity.ID).Logger()
 
@@ -297,22 +298,19 @@ func (t *BaselineClient) assignPoints() error {
 		}
 
 		// TODO(ae): need to add signature here still, must update devicees-api grpc response to do so
-		earningVehicle, ok := attestationData[*ud.Vin]
+		potentialEarner, ok := attestationData[*ud.Vin]
 		if ok {
-			credExp, ok := earningVehicle[CredentialExpiresAt]
-			if ok {
-				if credExp.(time.Time).Before(ud.LatestVinCredential.Expiration.AsTime()) {
-					attestationData[*ud.Vin] = map[string]interface{}{
-						CredentialExpiresAt: ud.LatestVinCredential.Expiration.AsTime(),
-						Values:              []interface{}{*ud.TokenId, ud.DeviceDefinitionId, ud.LatestVinCredential.Id},
-					}
+			if potentialEarner.VCExpiration.Before(ud.LatestVinCredential.Expiration.AsTime()) {
+				attestationData[*ud.Vin] = merkleTreeLeaf{
+					VCExpiration: ud.LatestVinCredential.Expiration.AsTime(),
+					Values:       []interface{}{*ud.TokenId, ud.DeviceDefinitionId, ud.LatestVinCredential.Id},
 				}
-
 			}
-		}
-		attestationData[*ud.Vin] = map[string]interface{}{
-			CredentialExpiresAt: ud.LatestVinCredential.Expiration.AsTime(),
-			Values:              []interface{}{*ud.TokenId, ud.DeviceDefinitionId, ud.LatestVinCredential.Id},
+		} else {
+			attestationData[*ud.Vin] = merkleTreeLeaf{
+				VCExpiration: ud.LatestVinCredential.Expiration.AsTime(),
+				Values:       []interface{}{*ud.TokenId, ud.DeviceDefinitionId, ud.LatestVinCredential.Id},
+			}
 		}
 
 		if err := thisWeek.Insert(ctx, t.TransferService.db.DBS().Writer, boil.Infer()); err != nil {

--- a/internal/services/rewards_test.go
+++ b/internal/services/rewards_test.go
@@ -405,9 +405,9 @@ func TestStreak(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			attestationService := NewAttestor(&logger)
 			transferService := NewTokenTransferService(&settings, nil, conn)
-
-			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, 5, &logger)
+			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, attestationService, 5, &logger)
 
 			err = rwBonusService.assignPoints()
 			if err != nil {
@@ -595,8 +595,8 @@ func TestBeneficiaryAddressSetForRewards(t *testing.T) {
 			}
 
 			transferService := NewTokenTransferService(&settings, nil, conn)
-
-			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, 5, &logger)
+			attestationService := NewAttestor(&logger)
+			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, attestationService, 5, &logger)
 
 			err = rwBonusService.assignPoints()
 			assert.NoError(t, err)
@@ -852,9 +852,9 @@ func TestBaselineIssuance(t *testing.T) {
 
 			producer.ExpectSendMessageWithCheckerFunctionAndSucceed(checker)
 
+			attestationService := NewAttestor(&logger)
 			transferService := NewTokenTransferService(&settings, producer, conn)
-
-			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, 5, &logger)
+			rwBonusService := NewBaselineRewardService(&settings, transferService, Views{devices: scen.Devices}, &FakeDevClient{devices: scen.Devices, users: scen.Users}, &FakeDefClient{}, attestationService, 5, &logger)
 
 			err = rwBonusService.BaselineIssuance()
 			assert.NoError(t, err)
@@ -1022,10 +1022,14 @@ func (d *FakeDevClient) GetUserDevice(_ context.Context, in *pb_devices.GetUserD
 		}
 
 		ud2 := &pb_devices.UserDevice{
-			Id:           ud.ID,
-			TokenId:      tk,
-			Vin:          vin,
-			OwnerAddress: owner,
+			Id:                 ud.ID,
+			TokenId:            tk,
+			Vin:                vin,
+			OwnerAddress:       owner,
+			DeviceDefinitionId: ksuid.New().String(),
+			LatestVinCredential: &pb_devices.VinCredential{
+				Id: ksuid.New().String(),
+			},
 		}
 
 		for _, i := range ud.IntsWithData {


### PR DESCRIPTION
- Add merkle tree generation to the rewards issuance process and log the root 
      - tree is generated after checks so it contains all devices that will earn for given week 
- in order to fulfill the requirements doc, this still needs the vc signature to be added (which means updating the grpc response from the devices api, I'll post a link to that pr here once I've done that)

Notes:
- There's several things we might want to store:
      - root and week number
      - proofs for each user 

Included below is the output of the test and the solidity contract and hardhat code I used to verify it

Contract: 
```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.9;

import "node_modules/@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";

contract Simple {
    constructor() {}

    function Verify(
        bytes32[] calldata _merkleProof,
        bytes32 storageMerkleRoot,
        bytes32 data
    ) public pure returns (bool) {
        return MerkleProof.verify(_merkleProof, storageMerkleRoot, data);
    }
}

```

Hardhat tests:
```javascript

  describe("Deployment", function () {
      it("rewards test", async function () {
      const { simple } = await loadFixture(deployOneYearLockFixture);
      expect(
        await simple.Verify(
          [
            "0x24afd3eb42056733b8fcdc968f4cd5053a21f73b45c243c9aec02acedd5021f6",
            "0x44a910b6135806f28d52453051bef92ad728dafc6e9620c52d1af2cdeb2bf998",
          ], //proof
          "0x06a0f4216bffb19713864b1f3020b3a7e505a4bcbe95e5df74a288189cb49e17", //root
          "0x02bf4c8c4f1649d724c6c06bdbce5978817a336f732403fd7ddd5116b562f47e" //data
        )
      ).to.equal(true);

      expect(
        await simple.Verify(
          [
            "0x02bf4c8c4f1649d724c6c06bdbce5978817a336f732403fd7ddd5116b562f47e",
            "0x44a910b6135806f28d52453051bef92ad728dafc6e9620c52d1af2cdeb2bf998",
          ], //proof
          "0x06a0f4216bffb19713864b1f3020b3a7e505a4bcbe95e5df74a288189cb49e17", //root
          "0x24afd3eb42056733b8fcdc968f4cd5053a21f73b45c243c9aec02acedd5021f6" //data
        )
      ).to.equal(true);

      expect(
        await simple.Verify(
          [
            "0x7fa502ce4199a9414e6df513252d1cfdb5cc9c99a2a8728ffbb52f54744dab83",
            "0xddc0e73f2c7000c4204febcafcd5ff181da1c02094b50243750ee2b3f83fd0e8",
          ], //proof
          "0x06a0f4216bffb19713864b1f3020b3a7e505a4bcbe95e5df74a288189cb49e17", //root
          "0x2c1a64fdb4f64cc638bc80466f2b7492a29d6359f5f490dd71eb6e050731c486" //data
        )
      ).to.equal(true);

      expect(
        await simple.Verify(
          [
            "0x2c1a64fdb4f64cc638bc80466f2b7492a29d6359f5f490dd71eb6e050731c486",
            "0xddc0e73f2c7000c4204febcafcd5ff181da1c02094b50243750ee2b3f83fd0e8",
          ], //proof
          "0x06a0f4216bffb19713864b1f3020b3a7e505a4bcbe95e5df74a288189cb49e17", //root
          "0x7fa502ce4199a9414e6df513252d1cfdb5cc9c99a2a8728ffbb52f54744dab83" //data
        )
      ).to.equal(true);
    });
  });

```