### PR TITLE
Pr 3880 optimize rewards vinvc retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ swag init -g cmd/rewards-api/main.go --parseDependency --parseInternal --parseDe
 ### Simulating a production run
 
 1. Get production values for the Clickohouse instance to place in `settings.yaml`. You will need to be on VPN for this to work.
-2. Set `DEFINITIONS_API_GRPC_ADDR` and `DEVICES_API_GRPC_ADDR` to local ports. For the sake of an example, let's say these are `localhost:8086` and `localhost:8087`, respectively.
-3. Port-forward these two services through. In our example:
+2. Set `DEFINITIONS_API_GRPC_ADDR`, `DEVICES_API_GRPC_ADDR`, and `FETCH_API_GRPC_ADDR` to local ports. For the sake of an example, let's say these are `localhost:8086`, `localhost:8087`, and `localhost:8088`, respectively.
+3. Port-forward these three services through. In our example:
    ```sh
    kubectl port-forward -n prod services/device-definitions-api-prod 8086:8086
    kubectl port-forward -n prod services/devices-api-prod 8087:8086
+   kubectl port-forward -n prod services/fetch-api-prod 8088:8086
    ```
 4. Run the job with, e.g., `go run ./cmd/rewards-api calculate 93`

--- a/charts/rewards-api/values.yaml
+++ b/charts/rewards-api/values.yaml
@@ -62,6 +62,7 @@ env:
   VINVC_DATA_VERSION: vin/v1.0
   MOBILE_API_BASE_URL: https://dimo-app-backend-development.up.railway.app
   STORAGE_NODE_DEV_LICENSE: '0x52fD9Dc294066792785CcD85eFB9A0Bd48DE01E4'
+  VINVC_CONCURRENCY_LIMIT: 5
 service:
   type: ClusterIP
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,6 @@ services:
       - POSTGRES_DB=rewards_api
     volumes:
       - ./resources/data:/var/log/postgresql/data:delegated
-  elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
-    container_name: es-rewards-api
-    ports:
-      - "9200:9200"
-    environment:
-      - xpack.security.enabled=false
-      - discovery.type=single-node
   zookeeper:
     image: "wurstmeister/zookeeper:latest"
     ports:
@@ -36,7 +28,3 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
       - zookeeper
-
-networks:
-  elastic:
-    driver: bridge

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -34,4 +34,5 @@ type Settings struct {
 	VINVCDataVersion           string          `yaml:"VINVC_DATA_VERSION"`
 	MobileAPIBaseURL           string          `yaml:"MOBILE_API_BASE_URL"`
 	StorageNodeDevLicense      common.Address  `yaml:"STORAGE_NODE_DEV_LICENSE"`
+	VINVCConcurrencyLimit      int             `yaml:"VINVC_CONCURRENCY_LIMIT"`
 }

--- a/internal/services/vinvc/vinstore.go
+++ b/internal/services/vinvc/vinstore.go
@@ -1,0 +1,44 @@
+package vinvc
+
+import (
+	"iter"
+	"sync"
+
+	"github.com/DIMO-Network/attestation-api/pkg/types"
+)
+
+// VINStore is a concurrent safe store for VIN subjects.
+type VINStore struct {
+	subjectsByVIN map[string][]*types.VINSubject
+	readLock      sync.RWMutex
+}
+
+// Add adds a subject to the VINStore for a given VIN.
+func (v *VINStore) Add(vin string, subject *types.VINSubject) {
+	v.readLock.Lock()
+	defer v.readLock.Unlock()
+	if v.subjectsByVIN == nil {
+		v.subjectsByVIN = make(map[string][]*types.VINSubject)
+	}
+	v.subjectsByVIN[vin] = append(v.subjectsByVIN[vin], subject)
+}
+
+// Get returns the subjects associated with a VIN.
+func (v *VINStore) Get(vin string) []*types.VINSubject {
+	v.readLock.RLock()
+	defer v.readLock.RUnlock()
+	return v.subjectsByVIN[vin]
+}
+
+// Items returns a concurrent safe iterator over the VINStore.
+func (v *VINStore) Items() iter.Seq2[string, []*types.VINSubject] {
+	return func(yield func(string, []*types.VINSubject) bool) {
+		v.readLock.RLock()
+		defer v.readLock.RUnlock()
+		for vin, subjects := range v.subjectsByVIN {
+			if !yield(vin, subjects) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
Do to a fix in the mobile job there are more VINVC created than before, and this is hurting the rewards job.
I am adding the following optimizations

1. Do not log an error every time we see a bad VINVC. Since we will try another VC we don't need to log each bad one. Other than having spam in the logs, logging also adds a noticeable amount of time.

2. Add concurrency to VINVC gathering. Getting a VINVC for each vehicle is independent of other vehicles so we can do these concurrently.

3. Fetch more than one VINVC at a time. happy path the first VINVC fetched is valid but if this is not true then we can grab a handful at once.